### PR TITLE
Fix leftover bugs from #2047 (#2194)

### DIFF
--- a/A3-Antistasi/Templates/Templates/VN/VN_MACV.sqf
+++ b/A3-Antistasi/Templates/Templates/VN/VN_MACV.sqf
@@ -70,7 +70,7 @@
 
 ["vehiclesArtillery", ["vn_b_army_static_m101_02"]] call _fnc_saveToTemplate;
 ["magazines", createHashMapFromArray [
-["vn_b_army_static_m101_02", ["vn_cannon_m101_mag_he_x8", "vn_cannon_m101_mag_ab_x8", "vn_cannon_m101_mag_wp_x8"]],
+["vn_b_army_static_m101_02", ["vn_cannon_m101_mag_he_x8", "vn_cannon_m101_mag_ab_x8", "vn_cannon_m101_mag_wp_x8"]]
 ]] call _fnc_saveToTemplate;
 
 ["uavsAttack", []] call _fnc_saveToTemplate;

--- a/A3-Antistasi/functions/CREATE/fn_createAIAirplane.sqf
+++ b/A3-Antistasi/functions/CREATE/fn_createAIAirplane.sqf
@@ -73,7 +73,7 @@ if (_frontierX) then
 		_vehiclesX pushBack _bunker;
 		_bunker setDir _dirveh;
 		_pos = getPosATL _bunker;
-		_typeVehX = _faction get "staticAT";
+		_typeVehX = selectRandom (_faction get "staticAT");
 		_veh = _typeVehX createVehicle _positionX;
 		_vehiclesX pushBack _veh;
 		_veh setDir _dirVeh + 180;


### PR DESCRIPTION
## What type of PR is this.
1. [X] Bug
2. [ ] Change
3. [ ] Enhancement

### What have you changed and why?
So far:
- Fixed trailing comma in MACV template causing init failures.
- Fixed array/string mismatch on staticAT causing airfield spawn failures.
    
### Please specify which Issue this PR Resolves.
closes #XXXX

### Please verify the following and ensure all checks are completed.
1. [ ] Have you loaded the mission in LAN host?
2. [ ] Have you loaded the mission on a dedicated server?

### Is further testing or are further changes required?
1. [ ] No
2. [ ] Yes (Please provide further detail below.)

* Fix trailing comma in MACV template

* Fix string/array mismatch on airport AT spawning

## What type of PR is this.
1. [ ] Bug
2. [ ] Change
3. [ ] Enhancement

### What have you changed and why?
Information:
    

### Please specify which Issue this PR Resolves.
closes #XXXX

### Please verify the following and ensure all checks are completed.

1. [ ] Have you loaded the mission in LAN host?
2. [ ] Have you loaded the mission on a dedicated server?

### Is further testing or are further changes required?
1. [ ] No
2. [ ] Yes (Please provide further detail below.)

### How can the changes be tested?
Steps: 

********************************************************
Notes:
